### PR TITLE
Updated element check to ensure that the object under inspection was …

### DIFF
--- a/XMI21Reader.js
+++ b/XMI21Reader.js
@@ -194,8 +194,8 @@ define(function (require, exports, module) {
                 var fun = elements[_type];
                 if (fun) {
                     var elem = fun(child);
-                    if (typeof elem !== "undefined" && elem !== null) {
-                        if (parentId) {
+                    if (typeof elem !== "undefined" && elem !== null && typeof elem === "object") {
+                        if (parentId ) {
                             elem._parent = { "$ref": parentId };
                         }
                         idMap[elem._id] = elem;
@@ -226,7 +226,7 @@ define(function (require, exports, module) {
                 var fun = elements[_type];
                 if (fun) {
                     var elem = fun(child);
-                    if (typeof elem !== "undefined" && elem !== null) {
+                    if (typeof elem !== "undefined" && elem !== null && typeof elem === "object") {
                         if (parentId) {
                             elem._parent = { "$ref": parentId };
                         }


### PR DESCRIPTION
…actually an object and not a primitive type.  I noticed an issue with Enterprise Architect v12, where an exported XMI file would not be imported as one of the values was an integer value and failed when trying to retrieve the _parentId property.  After this fix I was able to import without issuses.  I reported this issue earlier in the week but was not able to attach the XMI as it contains client data.  I did however fix the issue and am now submitting the fix back to the community.